### PR TITLE
CakePHP 4 and queuesadilla 0.7.0 fixes

### DIFF
--- a/src/Lib/Websocket.php
+++ b/src/Lib/Websocket.php
@@ -6,6 +6,7 @@ use Cake\Core\Configure;
 use Cake\Utility\Hash;
 use Exception;
 use Josegonzalez\CakeQueuesadilla\Queue\Queue;
+use josegonzalez\Queuesadilla\Job\Base;
 
 /**
  * Use this class to enqueue Websocket events
@@ -42,12 +43,24 @@ class Websocket
 
         $audience = Hash::merge(Configure::read('Websocket.events.' . $eventName . '.audience'), $audience);
 
-        return Queue::push($eventName, [
+        return Queue::push('\Websocket\Lib\Websocket::executeEvent', [
             'payload' => $payload,
             'audience' => $audience,
+            'event' => $eventName,
         ], [
             'queue' => Configure::read('Websocket.Queue.name'),
         ]);
+    }
+
+    /**
+     * Dummy placeholder function so valid callable is found.
+     *
+     * @param \josegonzalez\Queuesadilla\Job\Base $job Queuesadilla job
+     * @return bool
+     */
+    public static function executeEvent(Base $job): bool
+    {
+        return true;
     }
 
     /**

--- a/src/Lib/WebsocketInterface.php
+++ b/src/Lib/WebsocketInterface.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 namespace Websocket\Lib;
 
 use Cake\Core\Configure;
-use Cake\Network\Session;
+use Cake\Http\Session;
 use Exception;
 use Ratchet\ConnectionInterface;
 use Ratchet\Wamp\WampServerInterface;
@@ -21,16 +21,14 @@ class WebsocketInterface implements WampServerInterface
     /**
      * Cake Session instance
      *
-     * @var \Cake\Network\Session
+     * @var \Cake\Http\Session
      */
     private $__session = null;
 
     /**
      * Constructor
-     *
-     * @return void
      */
-    public function __construct(): void
+    public function __construct()
     {
         $this->__session = Session::create(Configure::read('Session'));
     }
@@ -43,7 +41,7 @@ class WebsocketInterface implements WampServerInterface
      */
     public function publishEvent(array $queueEntry): bool
     {
-        $eventName = $queueEntry['class'];
+        $eventName = $queueEntry['args'][0]['event'];
         $payload = $queueEntry['args'][0]['payload'];
         $audience = $queueEntry['args'][0]['audience'];
 
@@ -151,7 +149,7 @@ class WebsocketInterface implements WampServerInterface
             session_abort();
             $this->__session->id($sessionId);
             session_start();
-            $userId = $this->__session->read('Auth.User.id');
+            $userId = (string)$this->__session->read('Auth.User.id');
         }
 
         return $userId;

--- a/src/Lib/WebsocketWorker.php
+++ b/src/Lib/WebsocketWorker.php
@@ -45,14 +45,13 @@ class WebsocketWorker extends Base
      * @param \Websocket\Lib\WebsocketInterface $websocketInterface instance of websocket interface
      * @param \josegonzalez\Queuesadilla\Engine\EngineInterface $engine queue engine (MySQL hard coded)
      * @param \Psr\Log\LoggerInterface $logger logger to use (error logger hard coded)
-     * @return void
      */
     public function __construct(
         LoopInterface $loop,
         WebsocketInterface $websocketInterface,
         EngineInterface $engine,
         LoggerInterface $logger = null
-    ): void {
+    ) {
         $this->__loop = $loop;
         $this->__websocketInterface = $websocketInterface;
         $this->__logger = $logger;


### PR DESCRIPTION
1. Fixes Issue #14 
Using a dummy function, which is passed as callable to `Queue::push`; The `event name` itself is passed via the job's data field.

2. Fixing some minor issues, which occurred during testing
